### PR TITLE
Resolve initialization and super() errors in FragmentFingerprintEmbedding

### DIFF
--- a/rgfn/gfns/reaction_gfn/policies/action_embeddings.py
+++ b/rgfn/gfns/reaction_gfn/policies/action_embeddings.py
@@ -93,6 +93,9 @@ class FragmentFingerprintEmbedding(ActionEmbeddingBase):
     ):
         super().__init__(data_factory, hidden_dim)
         self.fingerprint_list = fingerprint_list
+        self.fragments = self.data_factory.get_fragments()
+        if not self.fragments:
+             print("Warning: FragmentFingerprintEmbedding received an empty fragment list from data_factory.")
 
         self.one_hot_weight = one_hot_weight
         self.one_hot = nn.Parameter(
@@ -147,7 +150,7 @@ class FragmentFingerprintEmbedding(ActionEmbeddingBase):
 
     def set_device(self, device: str, recursive: bool = True):
         self.all_fingerprints = self.all_fingerprints.to(device)
-        self.super().set_device(device, recursive=recursive)
+        super().set_device(device, recursive=recursive)
 
 
 @gin.configurable()


### PR DESCRIPTION
The FragmentFingerprintEmbedding class had two issues:

1. In `__init__`, `self.fragments` was accessed (e.g., for `len()`) before being assigned, causing an AttributeError during object creation. This is fixed by assigning `self.fragments` from the `data_factory` earlier in the initializer.

2. In `set_device`, the incorrect syntax `self.super()` was used instead of the built-in `super()` function to call the parent class's method, resulting in an AttributeError. This is corrected to `super().set_device(...)`.